### PR TITLE
Update Salesforce.pm to include optional url param

### DIFF
--- a/lib/WWW/Salesforce.pm
+++ b/lib/WWW/Salesforce.pm
@@ -499,7 +499,9 @@ package WWW::Salesforce;
             $errstr = "WWW::Salesforce::login() requires a password";
             return 0;
         }
-		
+	if ($params{'url'}) {
+       	    $SF_PROXY = $params{'url'};
+    	}
         my $self = {
             sf_user => $params{'username'},
             sf_pass => $params{'password'},


### PR DESCRIPTION
If you have a sandbox environment, you will be stuck hitting the production API, as there is no way to to pass in a sandbox URL.  This change will set $SF_PROXY to to the passed in URL, if provided.
